### PR TITLE
BC-36 # only extract String values into files

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -10,6 +10,7 @@ const loadJson = require('load-json-file');
 const pify = require('pify');
 const fsp = require('@jokeyrhyme/pify-fs');
 const isEqual = require('lodash.isequal');
+const isString = require('lodash.isstring');
 const mkdirpp = pify(require('mkdirp'));
 const traverse = require('traverse');
 const writeJson = require('write-json-file');
@@ -29,6 +30,15 @@ function getPathValue (data, dataPath) {
   return getPathValue(firstStep, dataPath.slice(1));
 }
 
+function isExtractableValue (value /* : any */) /* : boolean */ {
+  return isString(value);
+}
+
+/**
+returns a copy of the input data,
+but checks available references to external files,
+and replaces values with matching references (if any)
+*/
 function pruneReferencedValues (options) { // { data, originPath, refs }
   return new Promise((resolve) => {
     let result;
@@ -38,7 +48,11 @@ function pruneReferencedValues (options) { // { data, originPath, refs }
         return isEqual(ref.path, this.path);
       });
       if (matchingRefs.length) {
-        this.update({ $file: matchingRefs[0].target }, true);
+        const matchingRef = matchingRefs[0];
+        const value = getPathValue(options.data, matchingRef.path);
+        if (isExtractableValue(value)) {
+          this.update({ $file: matchingRef.target }, true);
+        }
       }
     });
     /* eslint-enable no-invalid-this */
@@ -53,9 +67,7 @@ function buildPlan (options) { // { data, originPath, refs, template }
       const targetPath = path.join(path.dirname(options.originPath), ref.target);
       return { targetPath, value };
     })
-    .filter((writeOp) => { // remove any with undefined value
-      return typeof writeOp.value !== 'undefined';
-    });
+    .filter((writeOp) => isExtractableValue(writeOp.value));
 
   return pruneReferencedValues(options)
     .then((result) => {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-standard": "^2.0.0",
     "fixpack": "^2.2.0",
     "flow-bin": "^0.32.0",
+    "greenkeeper-postpublish": "^1.0.1",
     "mkdirp": "^0.5.1",
     "nyc": "^8.1.0",
     "temp": "^0.8.3"
@@ -56,6 +57,7 @@
     "fixpack": "fixpack",
     "flow_check": "flow check || exit 0",
     "nyc": "nyc check-coverage",
+    "postpublish": "greenkeeper-postpublish",
     "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
     "test": "npm run ava && npm run nyc"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0",
     "fixpack": "^2.2.0",
-    "flow-bin": "^0.30.0",
+    "flow-bin": "^0.32.0",
     "mkdirp": "^0.5.1",
     "nyc": "^8.1.0",
     "temp": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@jokeyrhyme/pify-fs": "^1.0.1",
     "load-json-file": "^2.0.0",
     "lodash.isequal": "^4.0.0",
+    "lodash.isstring": "^4.0.1",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
     "traverse": "0.6.6",
@@ -52,7 +53,7 @@
     "url": "git+https://github.com/blinkmobile/json-as-files.js.git"
   },
   "scripts": {
-    "ava": "nyc ava tests/**/*.js",
+    "ava": "nyc ava tests/*.js",
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
     "flow_check": "flow check || exit 0",

--- a/tests/helpers/fs.js
+++ b/tests/helpers/fs.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const fsp = require('@jokeyrhyme/pify-fs');
+
+function assertFileNotExists (t, filePath) {
+  // Node >=6.3 uses fs.constants.F_OK, <6.3 uses fs.F_OK
+  return fsp.access(filePath, (fsp.constants || fsp).F_OK)
+    .then(() => t.fail(`${filePath} should not exist`))
+    .catch(() => t.pass(`${filePath} does not exist`));
+}
+
+module.exports = {
+  assertFileNotExists
+};

--- a/tests/plan-write-null-values.js
+++ b/tests/plan-write-null-values.js
@@ -1,0 +1,42 @@
+'use strict';
+
+// Node.js built-ins
+
+const path = require('path');
+
+// foreign modules
+
+const test = require('ava');
+
+// local modules
+
+const fsHelpers = require('./helpers/fs.js');
+const planWriteData = require('..').planWriteData;
+
+// this module
+
+const TARGET_FILE_PATH = path.join(__dirname, 'fixtures', 'foo.json');
+
+test(`${TARGET_FILE_PATH} does not exist`, (t) => {
+  // Node >=6.3 uses fs.constants.F_OK, <6.3 uses fs.F_OK
+  return fsHelpers.assertFileNotExists(t, TARGET_FILE_PATH);
+});
+
+test('template with "$file" + data with null values', (t) => {
+  const data = {
+    value: null
+  };
+  const template = {
+    value: {
+      $file: 'value.txt'
+    }
+  };
+  return planWriteData({ data, filePath: TARGET_FILE_PATH, template })
+    .then((result) => {
+      t.is(result.length, 1);
+      t.deepEqual(result[0], {
+        targetPath: TARGET_FILE_PATH,
+        value: data
+      });
+    });
+});

--- a/tests/write-old-refs.js
+++ b/tests/write-old-refs.js
@@ -13,6 +13,7 @@ const test = require('ava');
 
 // local modules
 
+const fsHelpers = require('./helpers/fs.js');
 const readData = require('..').readData;
 const writeData = require('..').writeData;
 
@@ -64,12 +65,8 @@ test('expected missing files: old-abc.txt, old-ghi.txt', (t) => {
   const ABC_PATH = path.join(TEMP_ROOT, 'old-abc.txt');
   const GHI_PATH = path.join(TEMP_ROOT, 'old-ghi.txt');
   return Promise.all([
-    fsp.access(ABC_PATH, fsp.F_OK)
-      .then(() => t.fail('resolved'))
-      .catch(() => t.pass('missing')),
-    fsp.access(GHI_PATH, fsp.F_OK)
-      .then(() => t.fail('resolved'))
-      .catch(() => t.pass('missing'))
+    fsHelpers.assertFileNotExists(t, ABC_PATH),
+    fsHelpers.assertFileNotExists(t, GHI_PATH)
   ]);
 });
 


### PR DESCRIPTION
### Fixed
-   BC-36: only extract String values into external files (@jokeyrhyme)
  -   avoids a mysterious "TypeError: Expected a plain object" when trying to extract `null`
  -   HelpDesk: 3691-FKCN-9070
